### PR TITLE
Allow hosting on ci and heroku

### DIFF
--- a/check_django/settings.py
+++ b/check_django/settings.py
@@ -31,7 +31,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['8000-craigallend-djangocheck-r1utdq7zshu.ws.codeinstitute-ide.net', 'herokuapp.com']
+ALLOWED_HOSTS = ['.codeinstitute-ide.net', '.herokuapp.com']
 
 
 # Application definition


### PR DESCRIPTION
Fix the allowed hosts for everyone, so that we don't need specific urls for each one.